### PR TITLE
Remove redundant constructor overrides. See #301

### DIFF
--- a/components/actions/base-actions/email-notifications.php
+++ b/components/actions/base-actions/email-notifications.php
@@ -59,15 +59,6 @@ final class Torro_Email_Notifications extends Torro_Form_Action {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing
 	 *
 	 * @since 1.0.0

--- a/components/actions/settings.php
+++ b/components/actions/settings.php
@@ -28,15 +28,6 @@ final class Torro_Form_Actions_Settings extends Torro_Settings {
 		return self::$instance;
 	}
 
-	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	public function init() {
 		$this->title = __( 'Actions', 'torro-forms' );
 		$this->name = 'actions';

--- a/components/form-settings/base-form-settings/access-controls/all-members.php
+++ b/components/form-settings/base-form-settings/access-controls/all-members.php
@@ -34,15 +34,6 @@ final class Torro_Form_Access_Control_All_Members extends Torro_Form_Access_Cont
 	}
 
 	/**
-	 * Constructor.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing.
 	 *
 	 * @since 1.0.0

--- a/components/form-settings/base-form-settings/access-controls/all-visitors.php
+++ b/components/form-settings/base-form-settings/access-controls/all-visitors.php
@@ -35,15 +35,6 @@ final class Torro_Form_Access_Control_All_Visitors extends Torro_Form_Access_Con
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing
 	 *
 	 * @since 1.0.0

--- a/components/form-settings/base-form-settings/access-controls/selected-members.php
+++ b/components/form-settings/base-form-settings/access-controls/selected-members.php
@@ -35,15 +35,6 @@ final class Torro_Form_Access_Control_Selected_Members extends Torro_Form_Access
 	}
 
 	/**
-	 * Constructor.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing.
 	 *
 	 * @since 1.0.0

--- a/components/form-settings/component.php
+++ b/components/form-settings/component.php
@@ -35,15 +35,6 @@ final class Torro_Form_Settings_Component extends Torro_Component {
 	}
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializes the Component
 	 *
 	 * @since 1.0.0

--- a/components/form-settings/settings.php
+++ b/components/form-settings/settings.php
@@ -29,15 +29,6 @@ final class Torro_Form_Settings_Settings extends Torro_Settings {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing
 	 *
 	 * @since 1.0.0

--- a/components/results/base-result-handlers/charts-c3.php
+++ b/components/results/base-result-handlers/charts-c3.php
@@ -33,15 +33,6 @@ final class Torro_Result_Charts_C3 extends Torro_Result_Charts {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializes the Component.
 	 *
 	 * @since 1.0.0

--- a/components/results/component.php
+++ b/components/results/component.php
@@ -35,15 +35,6 @@ final class Torro_Results_Component extends Torro_Component {
 	}
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializes the Component.
 	 *
 	 * @since 1.0.0

--- a/components/results/models/class-form-result.php
+++ b/components/results/models/class-form-result.php
@@ -28,15 +28,6 @@ abstract class Torro_Form_Result extends Torro_Base {
 	protected $option_content = '';
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Content of option in Form builder
 	 *
 	 * @param int $form_id

--- a/components/results/settings.php
+++ b/components/results/settings.php
@@ -29,15 +29,6 @@ final class Torro_Results_Settings extends Torro_Settings {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing
 	 *
 	 * @since 1.0.0

--- a/core/error.php
+++ b/core/error.php
@@ -21,10 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0-beta.1
  */
 class Torro_Error extends WP_Error {
-	public function __construct( $code = '', $message = '', $data = '' ) {
-		parent::__construct( $code, $message, $data );
-	}
-
 	public function __call( $function, $args ) {
 		if ( method_exists( $this, $function ) ) {
 			return call_user_func_array( array( $this, $function ), $args );

--- a/core/managers/class-access-controls-manager.php
+++ b/core/managers/class-access-controls-manager.php
@@ -33,10 +33,6 @@ final class Torro_Form_Access_Controls_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'access_controls' => 'Torro_Form_Access_Control'

--- a/core/managers/class-actions-manager.php
+++ b/core/managers/class-actions-manager.php
@@ -40,15 +40,6 @@ final class Torro_Form_Actions_Manager extends Torro_Manager {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Setting allowed mudules
 	 *
 	 * @return array

--- a/core/managers/class-components-manager.php
+++ b/core/managers/class-components-manager.php
@@ -33,10 +33,6 @@ final class Torro_Components_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules() {
 		$allowed = array(
 			'components' => 'Torro_Component'

--- a/core/managers/class-containers-manager.php
+++ b/core/managers/class-containers-manager.php
@@ -37,10 +37,6 @@ final class Torro_Containers_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new container.
 	 *

--- a/core/managers/class-element-answer-manager.php
+++ b/core/managers/class-element-answer-manager.php
@@ -37,10 +37,6 @@ final class Torro_Element_Answer_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new element answer.
 	 *

--- a/core/managers/class-element-setting-manager.php
+++ b/core/managers/class-element-setting-manager.php
@@ -37,10 +37,6 @@ final class Torro_Element_Setting_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new element setting.
 	 *

--- a/core/managers/class-element-types-manager.php
+++ b/core/managers/class-element-types-manager.php
@@ -34,10 +34,6 @@ final class Torro_Element_Types_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	public function get_class_name_by_type( $type ) {
 		$element_types = $this->get_all_registered();
 

--- a/core/managers/class-elements-manager.php
+++ b/core/managers/class-elements-manager.php
@@ -65,10 +65,6 @@ final class Torro_Elements_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new element.
 	 *

--- a/core/managers/class-email-notifications-manager.php
+++ b/core/managers/class-email-notifications-manager.php
@@ -37,10 +37,6 @@ final class Torro_Email_Notifications_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new email notification.
 	 *

--- a/core/managers/class-extensions-manager.php
+++ b/core/managers/class-extensions-manager.php
@@ -34,10 +34,6 @@ final class Torro_Extensions_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'extensions' => 'Torro_Extension'

--- a/core/managers/class-form-settings-manager.php
+++ b/core/managers/class-form-settings-manager.php
@@ -34,10 +34,6 @@ final class Torro_Form_Settings_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'form_setting' => 'Torro_Form_Setting'

--- a/core/managers/class-participants-manager.php
+++ b/core/managers/class-participants-manager.php
@@ -37,10 +37,6 @@ final class Torro_Participants_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new participant.
 	 *

--- a/core/managers/class-result-handlers-manager.php
+++ b/core/managers/class-result-handlers-manager.php
@@ -34,10 +34,6 @@ final class Torro_Form_Result_Handlers_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'resulthandlers' => 'Torro_Form_Result',

--- a/core/managers/class-result-values-manager.php
+++ b/core/managers/class-result-values-manager.php
@@ -37,10 +37,6 @@ final class Torro_Result_Values_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new result value.
 	 *

--- a/core/managers/class-results-manager.php
+++ b/core/managers/class-results-manager.php
@@ -37,10 +37,6 @@ final class Torro_Results_Manager extends Torro_Instance_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Creates a new result.
 	 *

--- a/core/managers/class-settings-manager.php
+++ b/core/managers/class-settings-manager.php
@@ -34,10 +34,6 @@ final class Torro_Settings_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'settings' => 'Torro_Settings'

--- a/core/managers/class-templatetags-manager.php
+++ b/core/managers/class-templatetags-manager.php
@@ -34,10 +34,6 @@ final class Torro_TemplateTags_Manager extends Torro_Manager {
 		return self::$instance;
 	}
 
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function allowed_modules(){
 		$allowed = array(
 			'templatetags' => 'Torro_Templatetags'

--- a/core/models/class-container.php
+++ b/core/models/class-container.php
@@ -50,17 +50,6 @@ class Torro_Container extends Torro_Instance_Base {
 	protected $elements = array();
 
 	/**
-	 * Torro_Container constructor.
-	 *
-	 * @param int $id
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
-	/**
 	 * Renders and returns the container HTML output.
 	 *
 	 * @since 1.0.0

--- a/core/models/class-element-answer.php
+++ b/core/models/class-element-answer.php
@@ -29,10 +29,6 @@ class Torro_Element_Answer extends Torro_Instance_Base {
 
 	protected $section = '';
 
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $element_id ) {
 		return parent::move( $element_id );
 	}

--- a/core/models/class-element-setting.php
+++ b/core/models/class-element-setting.php
@@ -27,10 +27,6 @@ class Torro_Element_Setting extends Torro_Instance_Base {
 
 	protected $value = '';
 
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $element_id ) {
 		return parent::move( $element_id );
 	}

--- a/core/models/class-email-notification.php
+++ b/core/models/class-email-notification.php
@@ -43,10 +43,6 @@ class Torro_Email_Notification extends Torro_Instance_Base {
 
 	protected $message = '';
 
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $element_id ) {
 		return parent::move( $element_id );
 	}

--- a/core/models/class-extension.php
+++ b/core/models/class-extension.php
@@ -50,15 +50,6 @@ abstract class Torro_Extension extends Torro_Base {
 	protected $version;
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Checking and starting
 	 *
 	 * @since 1.0.0

--- a/core/models/class-form.php
+++ b/core/models/class-form.php
@@ -62,17 +62,6 @@ class Torro_Form extends Torro_Instance_Base {
 	protected $container_index = -1;
 
 	/**
-	 * Constructor
-	 *
-	 * @param int $id The id of the form
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
-	/**
 	 * Setting Container id
 	 *
 	 * @param int $container_id

--- a/core/models/class-participant.php
+++ b/core/models/class-participant.php
@@ -28,10 +28,6 @@ class Torro_Participant extends Torro_Instance_Base {
 
 	protected $user;
 
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $form_id ) {
 		return parent::move( $form_id );
 	}

--- a/core/models/class-result-value.php
+++ b/core/models/class-result-value.php
@@ -31,17 +31,6 @@ class Torro_Result_Value extends Torro_Instance_Base {
 
 	protected $element = null;
 
-	/**
-	 * Torro_Container constructor.
-	 *
-	 * @param int $id
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $result_id ) {
 		return parent::move( $result_id );
 	}

--- a/core/models/class-result.php
+++ b/core/models/class-result.php
@@ -37,17 +37,6 @@ class Torro_Result extends Torro_Instance_Base {
 
 	protected $values = array();
 
-	/**
-	 * Torro_Container constructor.
-	 *
-	 * @param int $id
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct( $id = null ) {
-		parent::__construct( $id );
-	}
-
 	public function move( $form_id ) {
 		return parent::move( $form_id );
 	}

--- a/core/models/class-settings.php
+++ b/core/models/class-settings.php
@@ -33,15 +33,6 @@ abstract class Torro_Settings extends Torro_Base {
 	protected $sub_settings = array();
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Adding settings field by array
 	 *
 	 * @param array $settings_fields

--- a/core/models/class-templatetags.php
+++ b/core/models/class-templatetags.php
@@ -28,15 +28,6 @@ abstract class Torro_TemplateTags extends Torro_Base {
 	protected $tags = array();
 
 	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Add a tag to taglist
 	 *
 	 * @param       $description

--- a/core/settings/base-settings/extensions.php
+++ b/core/settings/base-settings/extensions.php
@@ -35,15 +35,6 @@ final class Torro_Extensions_Settings extends Torro_Settings {
 		return self::$instance;
 	}
 
-	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	public function init() {
 		$this->title = __( 'Extensions', 'torro-forms-conditional-logic' );
 		$this->name = 'extensions';

--- a/core/settings/base-settings/general.php
+++ b/core/settings/base-settings/general.php
@@ -36,15 +36,6 @@ final class Torro_General_Settings extends Torro_Settings {
 	}
 
 	/**
-	 * Constructor
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Initializing
 	 *
 	 * @since 1.0.0

--- a/core/templatetags/base-templatetags/form.php
+++ b/core/templatetags/base-templatetags/form.php
@@ -35,15 +35,6 @@ final class Torro_Templatetags_Form extends Torro_TemplateTags {
 		return self::$instance;
 	}
 
-	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function init() {
 		$this->title = __( 'Form', 'torro-forms' );
 		$this->name = 'formtags';

--- a/core/templatetags/base-templatetags/global.php
+++ b/core/templatetags/base-templatetags/global.php
@@ -35,15 +35,6 @@ final class Torro_Templatetags_Global extends Torro_TemplateTags {
 		return self::$instance;
 	}
 
-	/**
-	 * Initializing.
-	 *
-	 * @since 1.0.0
-	 */
-	protected function __construct() {
-		parent::__construct();
-	}
-
 	protected function init() {
 		$this->title = __( 'Global', 'torro-forms' );
 		$this->name = 'basetags';

--- a/tests/phpunit/includes/factory/factory-for-thing-with-children.php
+++ b/tests/phpunit/includes/factory/factory-for-thing-with-children.php
@@ -4,10 +4,6 @@ abstract class Torro_UnitTest_Factory_For_Thing_With_Children extends Torro_Unit
 	protected $child_factories = array();
 	protected $id_field_name;
 
-	public function __construct( $factory = null, $default_generation_definitions = array() ) {
-		parent::__construct( $factory, $default_generation_definitions );
-	}
-
 	public function create_full( $args = array() ) {
 		$children = array();
 		foreach ( $this->child_factories as $field_name => $factory_name ) {


### PR DESCRIPTION
The constructor overrides just reiterate the default behaviour, adding an additional method call without any benefit.