### PR TITLE
Use proper inheritance instead of `method_exists`. See #318

### DIFF
--- a/core/models/class-component.php
+++ b/core/models/class-component.php
@@ -72,8 +72,19 @@ abstract class Torro_Component extends Torro_Base {
 	 * @since 1.0.0
 	 */
 	private function base_init() {
-		if ( method_exists( $this, 'includes' ) ) {
-			$this->includes();
-		}
+		$this->includes();
+	}
+
+	/**
+	 * Optionally add includes.
+	 *
+	 * Override in child class if needed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function includes() {
+		// Override in child class to add includes.
 	}
 }

--- a/core/models/class-extension.php
+++ b/core/models/class-extension.php
@@ -78,13 +78,24 @@ abstract class Torro_Extension extends Torro_Base {
 	 * @since 1.0.0
 	 */
 	protected function base_init() {
-		if ( method_exists( $this, 'includes' ) ) {
-			$this->includes();
-		}
+		$this->includes();
 
 		if ( isset( $this->settings_fields['serial'] ) ) {
 			add_action( 'admin_init', array( $this, 'plugin_updater' ), 0 );
 		}
+	}
+
+	/**
+	 * Optionally add includes.
+	 *
+	 * Override in child class if needed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function includes() {
+		// Override in child class to add includes.
 	}
 
 	/**


### PR DESCRIPTION
Benefits as copied from Drupal docs:

- Code is not self-documented (no docblock for those ghost/dynamic methods).
- Method signature is not documented (method is not explicitely declared anywhere): it leaves the developer clueless about the arguments they should take, when they are called, and what he must do into those.
- Because method signature doesn't exists anywhere, there is no code consistency check at compilation time (for example, when signature diverge in which case the code is definitely broken) and errors remain silent.
- Runtime checks are bad when then can be done at compile time (it's always faster at compile time).
- Modern IDE's (I use Eclipse) cannot find those methods, therefore cannot neither outline them in code navigation pane, neither autocomplete on them.
- Code navigation is broken.