### PR TITLE
Bugfix

### DIFF
--- a/src/db-objects/elements/element-types/base/onechoice.php
+++ b/src/db-objects/elements/element-types/base/onechoice.php
@@ -75,7 +75,7 @@ class Onechoice extends Element_Type implements Choice_Element_Type_Interface {
 
 		$choices = $this->get_choices_for_field( $element );
 
-		if ( ! empty($value) && ! in_array( $value, $choices, true ) ) {
+		if ( ! empty( $value ) && ! in_array( $value, $choices, true ) ) {
 			return $this->create_error( 'value_invalid_choice', __( 'You must select a valid value from the list.', 'torro-forms' ), $value );
 		}
 

--- a/src/db-objects/elements/element-types/base/onechoice.php
+++ b/src/db-objects/elements/element-types/base/onechoice.php
@@ -75,7 +75,7 @@ class Onechoice extends Element_Type implements Choice_Element_Type_Interface {
 
 		$choices = $this->get_choices_for_field( $element );
 
-		if ( ! in_array( $value, $choices, true ) ) {
+		if ( ! empty($value) && ! in_array( $value, $choices, true ) ) {
 			return $this->create_error( 'value_invalid_choice', __( 'You must select a valid value from the list.', 'torro-forms' ), $value );
 		}
 


### PR DESCRIPTION
Despite "Required" is set to "no", I'm obliged to choose a value or it raises a "You must select a valid value from the list" error.

<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.8 and PHP 5.6.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
added "not empty" check on value's validation compared to the possible values' array

## How Has This Been Tested?
WordPress 4.9.5, theme: Twenty Seventeen

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.8 and PHP 5.6.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
