### PR TITLE
Update multiplechoice.php

### DIFF
--- a/src/db-objects/elements/element-types/base/multiplechoice.php
+++ b/src/db-objects/elements/element-types/base/multiplechoice.php
@@ -70,7 +70,7 @@ class Multiplechoice extends Element_Type implements Choice_Element_Type_Interfa
 	public function validate_field( $value, $element, $submission ) {
 		$settings = $this->get_settings( $element );
 
-		if ( $value != null ){
+		if ( null !== $value ) {
 			$value = (array) $value;
 		}
 

--- a/src/db-objects/elements/element-types/base/multiplechoice.php
+++ b/src/db-objects/elements/element-types/base/multiplechoice.php
@@ -70,7 +70,9 @@ class Multiplechoice extends Element_Type implements Choice_Element_Type_Interfa
 	public function validate_field( $value, $element, $submission ) {
 		$settings = $this->get_settings( $element );
 
-		$value = (array) $value;
+		if ( $value != null ){
+			$value = (array) $value;
+		}
 
 		if ( ! empty( $settings['required'] ) && 'no' !== $settings['required'] && empty( $value ) ) {
 			return $this->create_error( Element_Type::ERROR_CODE_REQUIRED, __( 'You must select at least a single value here.', 'torro-forms' ), $value );


### PR DESCRIPTION
bugfix: if it's required but none of checkbox is selected ===>>

Notice: Array to string conversion in C:\xampp\htdocs\WPSviluppoPlugin\wp-content\plugins\torro-forms\vendor\felixarntz\plugin-lib\src\db-objects\model.php on line 546

[code's snippet]
elseif ( is_string( $this->$property ) ) {
				$this->$property = strval( $value );
[code's snippet]

<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.8 and PHP 5.6.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.8 and PHP 5.6.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
