### PR TITLE
Submission Deletion: Cron never runs

### DIFF
--- a/src/db-objects/submissions/submission-manager.php
+++ b/src/db-objects/submissions/submission-manager.php
@@ -352,7 +352,7 @@ class Submission_Manager extends Manager {
 	 * @since 1.0.0
 	 */
 	public function schedule_cron_task() {
-		$settings = $this->get_parent_manager( 'forms' )->options()->get( 'general', array() );
+		$settings = $this->get_parent_manager( 'forms' )->options()->get( 'general_settings', array() );
 
 		if ( isset( $settings['delete_submissions'] ) && $settings['delete_submissions'] ) {
 			if ( ! wp_next_scheduled( "{$this->get_prefix()}cron_maybe_delete_submissions" ) ) {
@@ -381,7 +381,7 @@ class Submission_Manager extends Manager {
 	 * @since 1.0.0
 	 */
 	public function maybe_delete_submissions() {
-		$settings = $this->get_parent_manager( 'forms' )->options()->get( 'general', array() );
+		$settings = $this->get_parent_manager( 'forms' )->options()->get( 'general_settings', array() );
 
 		$delete = isset( $settings['delete_submissions'] ) ? (bool) $settings['delete_submissions'] : false;
 		if ( ! $delete ) {


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.8 and PHP 5.6.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Currently the "Submission Deletion" feature is broken and never runs due to using the wrong name when retrieving the corresponding option.

## How Has This Been Tested?
I didn't do any thorough testing or run any tests beyond changing this in my current project. But as this is a pretty simple fix I hope that suffices :innocent: :smile:
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.8 and PHP 5.6.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
