### PR TITLE
Bugfix on remove_error from submission

### DIFF
--- a/src/src/db-objects/submissions/submission.php
+++ b/src/src/db-objects/submissions/submission.php
@@ -602,7 +602,7 @@ class Submission extends Model {
 			return false;
 		}
 
-		if ( ! is_array( $this->pending_meta['errors'][ $element_id ][ $code ] ) ) {
+		if ( ! isset( $this->pending_meta['errors'][ $element_id ][ $code ] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Description
At this point i tested removing errors from submission, but actually the method tested the error_code message "itself" to be an array. That's not the fact of architecture.