### PR TITLE
Removed wpautop from escape_single_value_for_export

### DIFF
--- a/src/src/db-objects/elements/element-types/element-type.php
+++ b/src/src/db-objects/elements/element-types/element-type.php
@@ -616,11 +616,6 @@ abstract class Element_Type {
 						// Replace CSV delimiter.
 						$value = str_replace( ';', ',', $value );
 					}
-
-					// Add paragraphs if there are linebreaks.
-					if ( false !== strpos( $value, "\n" ) ) {
-						$value = wpautop( $value );
-					}
 				}
 				break;
 			case 'json':


### PR DESCRIPTION
This doesn't make sense when exporting values for XLS and CSV